### PR TITLE
Adds SSL only channel mode

### DIFF
--- a/help/opers/cmode
+++ b/help/opers/cmode
@@ -29,7 +29,8 @@ NO PARAMETERS:
               (however, new forwards can still be set subject to +F).
      +C     - Disable CTCP. All CTCP messages to the channel, except ACTION,
               are disallowed.
-
+     +S     - Only users connected via SSL may join the channel while this mode is set. Users already in the channel are not affected.
+     
 WITH PARAMETERS:
      +f     - Forward.  Forwards users who cannot join because of +i,
               +j, +l or +r.


### PR DESCRIPTION
Adds +S channel mode - Only users connected via SSL may join the channel while this mode is set. Users already in the channel are not affected.
